### PR TITLE
Fix flashing LineageOS 17.1

### DIFF
--- a/recovery/init.recovery.exynos9820.rc
+++ b/recovery/init.recovery.exynos9820.rc
@@ -1,4 +1,7 @@
 on init
+    # FIXME: Set avb_version to be able to flash LineageOS 17.1
+    setprop ro.boot.vbmeta.avb_version 1.1
+
     # mount debugfs
     mount debugfs /sys/kernel/debug /sys/kernel/debug mode=755
 

--- a/recovery/init.recovery.usb.rc
+++ b/recovery/init.recovery.usb.rc
@@ -1,3 +1,17 @@
+on init
+    chown system system /sys/class/android_usb/android0/enable
+    chmod 0660 /sys/class/android_usb/android0/enable
+    chown system system /sys/class/android_usb/android0/idVendor
+    chmod 0660 /sys/class/android_usb/android0/idVendor
+    chown system system /sys/class/android_usb/android0/idProduct
+    chmod 0660 /sys/class/android_usb/android0/idProduct
+    chown system system /sys/class/android_usb/android0/f_diag/clients
+    chmod 0660 /sys/class/android_usb/android0/f_diag/clients
+    chown system system /sys/class/android_usb/android0/functions
+    chmod 0660 /sys/class/android_usb/android0/functions
+    chown system system /sys/class/android_usb/android0/bDeviceClass
+    chmod 0660 /sys/class/android_usb/android0/bDeviceClass
+
 on post-fs
     mount configfs none /sys/kernel/config
     mkdir /sys/kernel/config/usb_gadget/g1 0770 shell shell

--- a/recovery/twrp.fstab
+++ b/recovery/twrp.fstab
@@ -10,7 +10,7 @@
 /recovery        emmc      /dev/block/platform/13d60000.ufs/by-name/recovery    flags=backup;flashimg
 /system_root     ext4      /dev/block/platform/13d60000.ufs/by-name/system      flags=backup;display="System"
 /system_image    emmc      /dev/block/platform/13d60000.ufs/by-name/system      flags=flashimg
-/vendor          ext4      /dev/block/platform/13d60000.ufs/by-name/vendor      flags=backup=1;display="Vendor";
+/vendor          ext4      /dev/block/platform/13d60000.ufs/by-name/vendor      flags=backup;wipeingui;display="Vendor"
 /vendor_image    emmc      /dev/block/platform/13d60000.ufs/by-name/vendor      flags=flashimg
 
 /sdcard1         auto     /dev/block/mmcblk0p1    /dev/block/mmcblk0            flags=display="Micro SDcard";storage;wipeingui;removable


### PR DESCRIPTION
This fixes flashing LineageOS 17.1 and also allows to wipe vendor.