### PR TITLE
Fix ril after CTC9

### DIFF
--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -114,6 +114,7 @@
 /(vendor|system/vendor)/bin/cass             u:object_r:cassd_exec:s0
 /(vendor|system/vendor)/bin/cbd              u:object_r:cbd_exec:s0
 /(vendor|system/vendor)/bin/epic             u:object_r:epicd_exec:s0
+/(vendor|system/vendor)/bin/secril_config_svc    u:object_r:secril_config_svc_exec:s0
 
 /(vendor|system/vendor)/bin/hw/gpsd          u:object_r:gpsd_exec:s0
 /(vendor|system/vendor)/bin/hw/lhd           u:object_r:lhd_exec:s0

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -17,7 +17,8 @@ ro.spid.gps.                   u:object_r:vendor_gps_prop:s0
 
 # RADIO
 persist.ril.                   u:object_r:radio_prop:s0
-ro.vendor.multisim.simslotcount u:object_r:vendor_radio_prop:s0
+ro.multisim.                   u:object_r:vendor_radio_prop:s0
+ro.vendor.multisim.            u:object_r:vendor_radio_prop:s0
 ro.vendor.radio.default_network u:object_r:vendor_radio_prop:s0
 vendor.gsm.                    u:object_r:vendor_radio_prop:s0
 

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -18,6 +18,7 @@ ro.spid.gps.                   u:object_r:vendor_gps_prop:s0
 # RADIO
 persist.ril.                   u:object_r:radio_prop:s0
 ro.vendor.multisim.simslotcount u:object_r:vendor_radio_prop:s0
+ro.vendor.radio.default_network u:object_r:vendor_radio_prop:s0
 vendor.gsm.                    u:object_r:vendor_radio_prop:s0
 
 # FACTORY

--- a/sepolicy/vendor/secril_config_svc.te
+++ b/sepolicy/vendor/secril_config_svc.te
@@ -1,0 +1,17 @@
+# secril_config_svc.te
+
+type secril_config_svc, domain;
+type secril_config_svc_exec, exec_type, vendor_file_type, file_type;
+
+# secril_config_svc is started by init, type transit from init domain to secril_config_svc domain
+init_daemon_domain(secril_config_svc)
+
+# /mnt/vendor/efs/factory.prop
+# /mnt/vendor/efs/telephony.prop
+allow secril_config_svc efs_file:dir search;
+allow secril_config_svc efs_file:file r_file_perms;
+
+# ro.multisim.
+# ro.vendor.multisim.
+# ro.vendor.radio.default_network
+set_prop(secril_config_svc, vendor_radio_prop)

--- a/sepolicy/vendor/vendor_init.te
+++ b/sepolicy/vendor/vendor_init.te
@@ -4,6 +4,7 @@ set_prop(vendor_init, vold_prop)
 set_prop(vendor_init, persist_rmnet_prop)
 set_prop(vendor_init, persist_data_df_prop)
 set_prop(vendor_init, persist_data_wda_prop)
+get_prop(vendor_init, vendor_radio_prop)
 
 # /
 allow vendor_init tmpfs:dir rw_dir_perms;


### PR DESCRIPTION
Still one issue with `persist.radio.multisim.config`

It is labeled as `exported3_radio_prop` but secril_config_svc wants to set it.