### PR TITLE
config: audio: Fix BT SCO sampling rate

### DIFF
--- a/config/audio/audio_policy_configuration_sec.xml
+++ b/config/audio/audio_policy_configuration_sec.xml
@@ -138,15 +138,15 @@
                 </devicePort>
                 <devicePort tagName="BT SCO" type="AUDIO_DEVICE_OUT_BLUETOOTH_SCO" role="sink">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
-                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+                             samplingRates="8000,16000" channelMasks="AUDIO_CHANNEL_OUT_MONO"/>
                 </devicePort>
                 <devicePort tagName="BT SCO Headset" type="AUDIO_DEVICE_OUT_BLUETOOTH_SCO_HEADSET" role="sink">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
-                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+                             samplingRates="8000,16000" channelMasks="AUDIO_CHANNEL_OUT_MONO"/>
                 </devicePort>
                 <devicePort tagName="BT SCO Car Kit" type="AUDIO_DEVICE_OUT_BLUETOOTH_SCO_CARKIT" role="sink">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
-                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+                             samplingRates="8000,16000" channelMasks="AUDIO_CHANNEL_OUT_MONO"/>
                 </devicePort>
                 <devicePort tagName="HDMI" type="AUDIO_DEVICE_OUT_AUX_DIGITAL" role="sink">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
@@ -214,11 +214,11 @@
                 <route type="mix" sink="HDMI"
                        sources="hdmi"/>
                 <route type="mix" sink="BT SCO"
-                       sources="primary output,deep_buffer,fast"/>
+                       sources="primary output,fast"/>
                 <route type="mix" sink="BT SCO Headset"
-                       sources="primary output,deep_buffer,fast"/>
+                       sources="primary output,fast"/>
                 <route type="mix" sink="BT SCO Car Kit"
-                       sources="primary output,deep_buffer,fast"/>
+                       sources="primary output,fast"/>
                 <route type="mix" sink="USB Device Out"
                        sources="primary output,deep_buffer,fast,direct_pcm,mmap_no_irq_out,hifi_playback"/>
                 <route type="mix" sink="USB Headset Out"


### PR DESCRIPTION
This is either 8000 (NB) or 16000 (WB). See also mixer_paths.xml.