### PR TITLE
platform: enforce rro for framework-res

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -23,6 +23,9 @@ PRODUCT_SOONG_NAMESPACES += \
 DEVICE_PACKAGE_OVERLAYS += \
     $(PLATFORM_PATH)/overlay
 
+PRODUCT_ENFORCE_RRO_TARGETS := \
+    framework-res
+
 ### RECOVERY
 ifeq ($(WITH_TWRP),true)
 # Add Timezone database


### PR DESCRIPTION
We might want this, it will generate /vendor/overlay/framework-res__auto_generated_rro_vendor.apk.