### PR TITLE
config: improve usb gadget device name

### DIFF
--- a/config/init/init.exynos9820.usb.rc
+++ b/config/init/init.exynos9820.usb.rc
@@ -22,8 +22,8 @@ on init
 
 on charger && property:ro.debuggable=1
     write /sys/kernel/config/usb_gadget/g1/strings/0x409/serialnumber ${ro.serialno}
-    write /sys/kernel/config/usb_gadget/g1/strings/0x409/manufacturer "SAMSUNG"
-    write /sys/kernel/config/usb_gadget/g1/strings/0x409/product "SAMSUNG_Android_lpm"
+    write /sys/kernel/config/usb_gadget/g1/strings/0x409/manufacturer ${ro.product.vendor.manufacturer}
+    write /sys/kernel/config/usb_gadget/g1/strings/0x409/product ${ro.product.vendor.model}
     write /sys/kernel/config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "Conf 1"
     symlink /sys/kernel/config/usb_gadget/g1/functions/ffs.adb /sys/kernel/config/usb_gadget/g1/configs/b.1/ffs.adb
     setprop sys.usb.configfs 1
@@ -31,8 +31,8 @@ on charger && property:ro.debuggable=1
 
 on boot
     write /sys/kernel/config/usb_gadget/g1/strings/0x409/serialnumber ${ro.serialno}
-    write /sys/kernel/config/usb_gadget/g1/strings/0x409/manufacturer "SAMSUNG"
-    write /sys/kernel/config/usb_gadget/g1/strings/0x409/product "SAMSUNG_Android"
+    write /sys/kernel/config/usb_gadget/g1/strings/0x409/manufacturer ${ro.product.vendor.manufacturer}
+    write /sys/kernel/config/usb_gadget/g1/strings/0x409/product ${ro.product.vendor.model}
     write /sys/kernel/config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "Conf 1"
     write /sys/kernel/config/usb_gadget/g1/configs/b.1/MaxPower 0x3f
     symlink /sys/kernel/config/usb_gadget/g1/functions/mtp.0 /sys/kernel/config/usb_gadget/g1/configs/b.1/mtp.0


### PR DESCRIPTION
Changes device name from SAMSUNG_SAMSUNG_Android to samsung_SM-G97{0,3,5}F