### PR TITLE
limit number of fingerprints to 4

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -351,4 +351,7 @@
     <!--
     <string name="config_defaultWellbeingPackage" translatable="false">com.samsung.android.forest</string>
     -->
+
+    <!-- FP trustled limits the number to 4. -->
+    <integer name="config_fingerprintMaxTemplatesPerUser">4</integer>
 </resources>


### PR DESCRIPTION
When 4 Fingerprints are registered we get a error trying to register a new fingerprint ... so limit them to 4.