### PR TITLE
board: really enable hdr and wide color display

### DIFF
--- a/BoardConfigPlatform.mk
+++ b/BoardConfigPlatform.mk
@@ -133,6 +133,8 @@ BOARD_CUSTOM_BT_CONFIG := $(PLATFORM_PATH)/hardware/bluetooth/libbt_vndcfg.txt
 ### GRAPHICS
 # hardware/interfaces/configstore/1.1/default/surfaceflinger.mk
 NUM_FRAMEBUFFER_SURFACE_BUFFERS := 3
+TARGET_HAS_HDR_DISPLAY := true
+TARGET_HAS_WIDE_COLOR_DISPLAY := true
 
 ### HIDL
 DEVICE_MANIFEST_FILE += $(PLATFORM_PATH)/manifest.xml


### PR DESCRIPTION
setting the surfaceflinger props does not enable HDR/Wide Color Display support
we also need to set the BoardConfig flags for configstore