### PR TITLE
init: move chown for tsp cmd node to earlier stage

### DIFF
--- a/config/init/init.exynos9820.root.rc
+++ b/config/init/init.exynos9820.root.rc
@@ -1,4 +1,7 @@
 on init
+    # for tsp cmd node
+    chown system radio /sys/class/sec/tsp/cmd
+
     # for audit message
     chown system system /proc/avc_msg
     chmod 0660 /proc/avc_msg
@@ -308,7 +311,6 @@ on boot
     chown system system /sys/devices/virtual/data_on
 
     # Permissions for Touchscreen
-    chown system radio /sys/class/sec/tsp/cmd
     chown system system /sys/class/sec/tsp/input/enabled
     chmod 0660 /sys/class/sec/tsp/input/enabled
     chown root system /proc/tsp_msg


### PR DESCRIPTION
we need this to enable FOD in FOD HAL initialization

See https://review.lineageos.org/c/LineageOS/android_hardware_samsung/+/279938