### PR TITLE
exynos9820: enable support for extended length nfc

### DIFF
--- a/config/nfc/libnfc-sec-vendor.conf
+++ b/config/nfc/libnfc-sec-vendor.conf
@@ -1,0 +1,123 @@
+## --------------- Part-I : Configuration for Phone HW ----------------------------##
+####################################################################################
+# I-1) Clock Source Information (AP direct 26MHz)
+####################################################################################
+## Clock option for 26MHz PLL (0x12)
+## Clock option for 19.2MHz PLL (0x11)
+FW_CFG_CLK_SPEED=0x12
+####################################################################################
+
+
+## --------------- Part-II : Configuration for Chip / FW -------------------------##
+####################################################################################
+# II-1) FW base address : 
+####################################################################################
+## FW Base Address for SEN82 (0x2000)
+FW_BASE_ADDRESS=0x2000
+####################################################################################
+# II-2) Timing parameter 
+####################################################################################
+# WAKEUP_DELAY for eSE Model
+# (Old F/W) 		 20ms : UICC, 80ms : eSE
+# (After Star Model) 20ms : UICC, 20ms : eSE
+#WAKEUP_DELAY=20
+####################################################################################
+# II-3) Firmware path
+####################################################################################
+## F/W image for S3NRN82
+#FW_IMAGE="/vendor/firmware/nfc/sec_s3nrn82_firmware.bin"
+
+# for single SKU
+FW_DIR_PATH="/vendor/firmware/nfc/"
+FW_FILE_NAME="sec_s3nrn82_firmware.bin"
+
+####################################################################################
+# II-4) RF Register path
+####################################################################################
+## RF Register for S3NRN82
+#RFREG_FILE="/vendor/etc/nfc/sec_s3nrn82_rfreg.bin"
+
+RF_DIR_PATH="/vendor/etc/nfc/"
+RF_FILE_NAME="sec_s3nrn82_rfreg.bin"
+## --------------- Part-III : Configuration for MW --------------------------------##
+####################################################################################
+# III-1) Driver path 
+####################################################################################
+## Power driver
+POWER_DRIVER="/dev/sec-nfc"
+## Transport driver
+TRANS_DRIVER="/dev/sec-nfc"
+
+
+####################################################################################
+# III-2) Trace Level 
+####################################################################################
+## TRACE_LEVEL  (0: only err, 1: and debug, 2: trace also)
+## DATA TRACE level (0: not display, 1: simply, 2: all of data trace)
+TRACE_LEVEL=2
+DATA_TRACE=2
+
+####################################################################################
+# III-3) NFC Sleep Timing
+####################################################################################
+# Set wait time to enter CLF sleep mode
+SLEEP_TIMEOUT=1000
+
+
+####################################################################################
+# III-4) F/W Update Option
+# F/W Update Option
+# 0 : Download for different version
+# 1 : Download for upper version
+# 2 : Force Download
+####################################################################################
+# 0 : Default value is "Download for different version"
+FW_UPDATE_MODE=0
+####################################################################################
+
+
+
+
+###############################################################################
+# Configure the default NfcA/IsoDep techology and protocol route. Can be
+# either a secure element (e.g. 0x02) or the host (0x00)
+DEFAULT_ROUTE=0x03
+###############################################################################
+# Configure the single default SE to use.  The default is to use the first
+# SE that is detected by the stack.  This value might be used when the phone
+# supports multiple SE but you want to force it to use one of them
+DEFAULT_OFFHOST_ROUTE=0x02
+
+###############################################################################
+# Choose the presence-check algorithm for type-4 tag.  If not defined, the default value is 1.
+# PRESENCE_CHECK_ALGORITHM=0    : [default] Automatic select for below 4 method.
+# PRESENCE_CHECK_ALGORITHM=1    : Read Empty I block.
+# PRESENCE_CHECK_ALGORITHM=2    : Sleep/Wakeup Command
+# PRESENCE_CHECK_ALGORITHM=3    : Read binary for CH0(K version method)
+# PRESENCE_CHECK_ALGORITHM=4    : Read binary for CH3
+# PRESENCE_CHECK_ALGORITHM=5    : ACK/NACK
+# Default : No use (AUTO)
+# For China Region : Use Method 3
+###############################################################################
+PRESENCE_CHECK_ALGORITHM=5
+
+###############################################################################
+# Vendor Specific Proprietary Protocol & Discovery Configuration
+# Set to 0xFF if unsupported
+#  byte[0] NCI_PROTOCOL_18092_ACTIVE
+#  byte[1] NCI_PROTOCOL_B_PRIME
+#  byte[2] NCI_PROTOCOL_DUAL
+#  byte[3] NCI_PROTOCOL_15693
+#  byte[4] NCI_PROTOCOL_KOVIO
+#  byte[5] NCI_PROTOCOL_MIFARE
+#  byte[6] NCI_DISCOVERY_TYPE_POLL_KOVIO
+#  byte[7] NCI_DISCOVERY_TYPE_POLL_B_PRIME
+#  byte[8] NCI_DISCOVERY_TYPE_LISTEN_B_PRIME
+NFA_PROPRIETARY_CFG={00, 81, 82, 80, 8A, 81, 70, 74, F4}
+###############################################################################
+# Extended APDU length for ISO_DEP. If not supported default length is 261 
+# CHECK in VTS Test case
+# ISO_DEP_MAX_TRANSCEIVE=0xFEFF
+ISO_DEP_MAX_TRANSCEIVE=0xFEFF
+
+############### end of config ##############################

--- a/platform/config.mk
+++ b/platform/config.mk
@@ -28,6 +28,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(PLATFORM_PATH)/config/keylayout/gpio_keys.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/gpio_keys.kl
 
+### NFC
+PRODUCT_COPY_FILES += \
+    $(PLATFORM_PATH)/config/nfc/libnfc-sec-vendor.conf:$(TARGET_COPY_OUT_VENDOR)/etc/libnfc-sec-vendor.conf
+
 ### WIFI
 PRODUCT_COPY_FILES += \
     $(PLATFORM_PATH)/config/wifi/p2p_supplicant_overlay.conf:$(TARGET_COPY_OUT_VENDOR)/etc/wifi/p2p_supplicant_overlay.conf \


### PR DESCRIPTION
Needed for e.g https://f-droid.org/de/packages/com.governikus.ausweisapp2/

increases ISO_DEP_MAX_TRANSCEIVE from 261 to 0xFEFF