### PR TITLE
Fix build of libshim_sensorndkbridge.

### DIFF
--- a/shim/sensorsndkbridge/Android.mk
+++ b/shim/sensorsndkbridge/Android.mk
@@ -20,7 +20,8 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := ASensorManager.cpp
 LOCAL_SHARED_LIBRARIES := \
     libbase \
-    libsensorndkbridge
+    libsensorndkbridge \
+    libutils
 LOCAL_MODULE := libshim_sensorndkbridge
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_CLASS := SHARED_LIBRARIES


### PR DESCRIPTION
I got
ld.lld: error: undefined symbol: android::RefBase::weakref_type::decWeak(void const*)
>>> referenced by RefBase.h:536 (system/core/libutils/include/utils/RefBase.h:536)
>>>               out/target/product/beyond1lte/obj/SHARED_LIBRARIES/libshim_sensorndkbridge_intermediates/ASensorManager.o:(std::__1::__tree<android::wp<ASensorEventQueue>, std::__1::less<android::wp<ASensor

Add libutils to the list of libs to link with.